### PR TITLE
fix licenses link

### DIFF
--- a/components/footer.html
+++ b/components/footer.html
@@ -7,7 +7,7 @@
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/404.html
+++ b/www/404.html
@@ -106,7 +106,7 @@
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/api/index.html
+++ b/www/api/index.html
@@ -108,7 +108,7 @@ API
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/browse/index.html
+++ b/www/browse/index.html
@@ -163,7 +163,7 @@ max-width: 640px;
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/code/index.html
+++ b/www/code/index.html
@@ -204,7 +204,7 @@ Code
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/categories/index.html
+++ b/www/docs/categories/index.html
@@ -188,7 +188,7 @@ whosonfirst-categories
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/concordances/index.html
+++ b/www/docs/concordances/index.html
@@ -197,7 +197,7 @@ Concordances
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/contributing/index.html
+++ b/www/docs/contributing/index.html
@@ -189,7 +189,7 @@ See also
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/dates/index.html
+++ b/www/docs/dates/index.html
@@ -188,7 +188,7 @@ whosonfirst-dates
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/geometries/alt/index.html
+++ b/www/docs/geometries/alt/index.html
@@ -113,7 +113,7 @@ What is an alt-geometry and how are they defined and catalogued in Who&#39;s On 
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/geometries/altgeometries.html
+++ b/www/docs/geometries/altgeometries.html
@@ -655,7 +655,7 @@ https://github.com/whosonfirst/whosonfirst-geometries
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/geometries/index.html
+++ b/www/docs/geometries/index.html
@@ -91,7 +91,7 @@ whosonfirst-geometries
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/hierarchies/disputedareas.html
+++ b/www/docs/hierarchies/disputedareas.html
@@ -237,7 +237,7 @@ Occasionally we will assign a value of -2. This should be interpreted as “:shr
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/hierarchies/index.html
+++ b/www/docs/hierarchies/index.html
@@ -260,7 +260,7 @@ Hierarchies
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/hierarchies/superseded.html
+++ b/www/docs/hierarchies/superseded.html
@@ -251,7 +251,7 @@ Like many signals its precise meaning and significance and how it should be hand
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/index.html
+++ b/www/docs/index.html
@@ -203,7 +203,7 @@ There are lots of tools for working with GeoJSON and, importantly, for convertin
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/keyterms/index.html
+++ b/www/docs/keyterms/index.html
@@ -188,7 +188,7 @@ Key terms
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/licenses/index.html
+++ b/www/docs/licenses/index.html
@@ -188,7 +188,7 @@ Data licenses
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/licensing/datalicenses.html
+++ b/www/docs/licensing/datalicenses.html
@@ -303,7 +303,7 @@ https://creativecommons.org/licenses/
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/names/index.html
+++ b/www/docs/names/index.html
@@ -188,7 +188,7 @@ whosonfirst-names
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/placetypes/index.html
+++ b/www/docs/placetypes/index.html
@@ -191,7 +191,7 @@ handy wof-graph-placetypes script in the py-mapzen-whosonfirst-placetypes librar
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/processes/assigningcessation.html
+++ b/www/docs/processes/assigningcessation.html
@@ -352,7 +352,7 @@ https://github.com/whosonfirst/whosonfirst-dates
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/processes/cessation-deprecation/index.html
+++ b/www/docs/processes/cessation-deprecation/index.html
@@ -149,7 +149,7 @@ Assigning Cessation and Deprecated Dates
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/processes/index.html
+++ b/www/docs/processes/index.html
@@ -157,7 +157,7 @@ Processes and Workflows
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/processes/s3-import/index.html
+++ b/www/docs/processes/s3-import/index.html
@@ -149,7 +149,7 @@ What is Required for S3 Import Files?
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/processes/s3requirements.html
+++ b/www/docs/processes/s3requirements.html
@@ -441,7 +441,7 @@ If a record has more than one parent record, include one of the following values
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/processes/san-francisco-neighbourhoods/index.html
+++ b/www/docs/processes/san-francisco-neighbourhoods/index.html
@@ -152,7 +152,7 @@ Updating Who&#39;s On First Neighbourhood Records (part one)
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/processes/seattle-neighbourhoods/index.html
+++ b/www/docs/processes/seattle-neighbourhoods/index.html
@@ -148,7 +148,7 @@
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/processes/seattleneighborhoodupdates.html
+++ b/www/docs/processes/seattleneighborhoodupdates.html
@@ -486,7 +486,7 @@ fields automatically updated to reflect newly merged geometry
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/processes/significant-event/index.html
+++ b/www/docs/processes/significant-event/index.html
@@ -148,7 +148,7 @@
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/processes/significantevent.html
+++ b/www/docs/processes/significantevent.html
@@ -406,7 +406,7 @@ email
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/processes/updatingsanfrancisconeighborhoods.html
+++ b/www/docs/processes/updatingsanfrancisconeighborhoods.html
@@ -3205,7 +3205,7 @@ Thanks for reading and happy mapping!
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/processes/wikipedia-concordances/index.html
+++ b/www/docs/processes/wikipedia-concordances/index.html
@@ -210,7 +210,7 @@ result_request=requests.get(request_API)
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/processes/wikipediaconcordances.html
+++ b/www/docs/processes/wikipediaconcordances.html
@@ -590,7 +590,7 @@ concordances
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/processes/wof-life-cycle/index.html
+++ b/www/docs/processes/wof-life-cycle/index.html
@@ -149,7 +149,7 @@ Who&#39;s On First ID Life Cycle Documentation
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/processes/woflifecycle.html
+++ b/www/docs/processes/woflifecycle.html
@@ -1294,7 +1294,7 @@ should also be minted and superseding work should take place, as outlined above
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/properties/addr/index.html
+++ b/www/docs/properties/addr/index.html
@@ -173,7 +173,7 @@ addr
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/brooklynintegers/index.html
+++ b/www/docs/properties/brooklynintegers/index.html
@@ -173,7 +173,7 @@ Brooklyn Integers
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/edtf/index.html
+++ b/www/docs/properties/edtf/index.html
@@ -173,7 +173,7 @@ edtf
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/geom/index.html
+++ b/www/docs/properties/geom/index.html
@@ -173,7 +173,7 @@ geom
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/index.html
+++ b/www/docs/properties/index.html
@@ -239,7 +239,7 @@ Properties
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/lbl/index.html
+++ b/www/docs/properties/lbl/index.html
@@ -173,7 +173,7 @@ lbl
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/mz/index.html
+++ b/www/docs/properties/mz/index.html
@@ -173,7 +173,7 @@ mz
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/name/index.html
+++ b/www/docs/properties/name/index.html
@@ -173,7 +173,7 @@ name
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/resto/index.html
+++ b/www/docs/properties/resto/index.html
@@ -173,7 +173,7 @@ resto
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/reversegeo/index.html
+++ b/www/docs/properties/reversegeo/index.html
@@ -173,7 +173,7 @@ reversegeo
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/src/index.html
+++ b/www/docs/properties/src/index.html
@@ -173,7 +173,7 @@ src
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/properties/wof/index.html
+++ b/www/docs/properties/wof/index.html
@@ -173,7 +173,7 @@ wof
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/sources/index.html
+++ b/www/docs/sources/index.html
@@ -91,7 +91,7 @@ whosonfirst-sources
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/sources/list/index.html
+++ b/www/docs/sources/list/index.html
@@ -113,7 +113,7 @@ sources
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/sources/listofsources.html
+++ b/www/docs/sources/listofsources.html
@@ -7432,7 +7432,7 @@ http://chicagomap.zolk.com/about.html
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/docs/spr/index.html
+++ b/www/docs/spr/index.html
@@ -252,7 +252,7 @@ curl -s 'http://localhost:8080/?latitude=37.787221&longitude=-122.400098&placety
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/tests/index.html
+++ b/www/docs/tests/index.html
@@ -188,7 +188,7 @@ whosonfirst-tests
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/docs/uris/index.html
+++ b/www/docs/uris/index.html
@@ -250,7 +250,7 @@ URIs
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/download/index.html
+++ b/www/download/index.html
@@ -259,7 +259,7 @@ Downloading Who&#39;s On First
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/getstarted/index.html
+++ b/www/getstarted/index.html
@@ -135,7 +135,7 @@ Get Started
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/getstarted/retrieveneighbourhoods.html
+++ b/www/getstarted/retrieveneighbourhoods.html
@@ -436,7 +436,7 @@ Congrats, you just made a map of San Francisco&#39;s neighbourhoods using the Ma
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../docs/contributing" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../docs/licensing" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../docs/licenses" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/getstarted/retrieveneighbourhoods/index.html
+++ b/www/getstarted/retrieveneighbourhoods/index.html
@@ -335,7 +335,7 @@ var oncomplete = function() { return; };</code></pre>
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/getstarted/retrievevenues.html
+++ b/www/getstarted/retrievevenues.html
@@ -448,7 +448,7 @@ Congrats, you just made a map of venues in New York City&#39;s Flatiron District
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../docs/contributing" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../docs/licensing" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../docs/licenses" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/getstarted/retrievevenues/index.html
+++ b/www/getstarted/retrievevenues/index.html
@@ -349,7 +349,7 @@ var show_venue = function(place) {
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/index.html
+++ b/www/index.html
@@ -194,7 +194,7 @@
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/interns/index.html
+++ b/www/interns/index.html
@@ -98,7 +98,7 @@
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/reference/homehalfgrid.html
+++ b/www/reference/homehalfgrid.html
@@ -200,7 +200,7 @@
 						<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 							<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 							<li><a href="v2/docs/contributing/index.html" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-							<li><a href="v2/docs/licensing/index.html" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+							<li><a href="v2/docs/licenses/index.html" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 							<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 							<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 							<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/reference/styleguide.html
+++ b/www/reference/styleguide.html
@@ -507,7 +507,7 @@ $&gt; git lfs ls-files
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
@@ -521,7 +521,7 @@ $&gt; git lfs ls-files
       &lt;ul class="nav navbar-nav navbar-right whosonfirst-footer">
         &lt;li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a &lt;a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen&lt;/a> gig&lt;/li>
         &lt;li>&lt;a href="../../docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing&lt;/a>&lt;/li>
-        &lt;li>&lt;a href="../../docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing&lt;/a>&lt;/li>
+        &lt;li>&lt;a href="../../docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing&lt;/a>&lt;/li>
         &lt;li>&lt;a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github&lt;/a>&lt;/li>
         &lt;li>&lt;a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github&lt;/a>&lt;/li>
         &lt;li>&lt;a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter&lt;/a>&lt;/li>

--- a/www/testpages/getstarted.html
+++ b/www/testpages/getstarted.html
@@ -191,7 +191,7 @@ S3 bucket called whosonfirst.mapzen.com in a sub-directory, or prefix in AWS-spe
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../docs/contributing" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../docs/licensing" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../docs/licenses" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/tools/availabletools.html
+++ b/www/tools/availabletools.html
@@ -215,7 +215,7 @@ A simple Flask-based spelunker for poking around Who&#39;s On First data
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li class="whosonfirst-nav-link-nounderline whoosonfooter-gig">who's on first is a <a href="https://mapzen.com/" class="whosonfirst-nav-link whosonfirst-nav-link-innounderline">mapzen</a> gig</li>
 						<li><a href="../docs/contributing" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="../docs/licensing" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
+						<li><a href="../docs/licenses" class="whosonfirst-nav-link whosonfirst-footer-nav-link">licensing</a></li>
 						<li><a href="https://github.com/whosonfirst" class="whosonfirst-nav-link whosonfirst-footer-nav-link">code github</a></li>
 						<li><a href="https://github.com/whosonfirst-data" class="whosonfirst-nav-link whosonfirst-footer-nav-link">data github</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>

--- a/www/tools/index.html
+++ b/www/tools/index.html
@@ -137,7 +137,7 @@ Tools
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>

--- a/www/what/index.html
+++ b/www/what/index.html
@@ -130,7 +130,7 @@ What is Who&#39;s On First?
 					<!-- Collect the nav links, forms, and other content for toggling -->
 					<ul class="nav navbar-nav navbar-right whosonfirst-footer">
 						<li><a href="/docs/contributing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">contributing</a></li>
-						<li><a href="/docs/licensing/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
+						<li><a href="/docs/licenses/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">license</a></li>
 						<li><a href="https://twitter.com/alloftheplaces/" class="whosonfirst-nav-link whosonfirst-footer-nav-link">twitter</a></li>
 					</ul>
 				</div>


### PR DESCRIPTION
The license link at the bottom of each page should point to `/docs/licenses/`, not `/docs/licensing/`.

Includes changes made in #50.